### PR TITLE
feat: Add github-default-dark theme

### DIFF
--- a/themes/github-default-dark.json
+++ b/themes/github-default-dark.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0",
+  "theme": {
+    "textColor": "#c9d1d9",
+    "backgroundColor": "#0d1117",
+    "matchBackgroundColor": "#698eda",
+    "selection": {
+      "textColor": "#c9d1d9",
+      "backgroundColor": "#1e6feb"
+    },
+    "description": {
+      "textColor": "#8b949e",
+      "borderColor": "#30363d"
+    }
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Adds `github-default-dark` theme based off of GitHub's `Default dark` theme

**What is the current behavior? (You can also link to an open issue here)**
The existing `github-dark` theme doesn't match the `Default dark` GitHub site theme

**What is the new behavior (if this is a feature change)?**
n/a

**Additional info:**
Didn't include an author section as I didn't really come up with the theme, only implemented it for fig (the existing `github-dark` theme didn't have one either). Let me know if an author section is needed and I can update the PR.