### PR TITLE
Added JSON Schema & Synthwave-84 Theme

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,104 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Fig Theme ✨",
+    "description": "Describes what colors Fig uses.",
+    "$comment": "TODO: add better description?",
+    "type": "object",
+    "properties": {
+        "author": {
+            "type": "object",
+            "title": "Author",
+            "description": "Information about the amazing person who created this theme.",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the author.",
+                    "example": "Linus Torvalds"
+                },
+                "twitter": {
+                    "type": "string",
+                    "description": "The Twitter handle of the author.",
+                    "example": "@torvalds"
+                },
+                "github": {
+                    "type": "string",
+                    "description": "The GitHub username of the author.",
+                    "example": "torvalds"
+                }
+            },
+            "required": ["name"]
+        },
+        "version": {
+            "type": "string",
+            "title": "Version",
+            "description": "The SemVer version of the theme.",
+            "example": "1.0.0"
+        },
+
+        "theme": {
+            "type": "object",
+            "title": "Color Theme",
+            "markdownDescription": "The colors used in the theme.\n\nTheme colors can be any valid [CSS color](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) value.",
+            "properties": {
+                "textColor": {
+                    "title": "Text Color",
+                    "$ref": "#/definitions/color"
+                },
+                "backgroundColor": {
+                    "title": "Background Color",
+                    "$ref": "#/definitions/color"
+                },
+                "matchBackgroundColor": {
+                    "title": "Match Background Color",
+                    "$ref": "#/definitions/color"
+                },
+                "selection": {
+                    "type": "object",
+                    "title": "Selection",
+                    "description": "The colors used for the currently selected autocompletion.",
+                    "properties": {
+                        "backgroundColor": {
+                            "title": "Selection Background Color",
+                            "$ref": "#/definitions/color"
+                        },
+                        "textColor": {
+                            "title": "Selection Text Color",
+                            "$ref": "#/definitions/color"
+                        }
+                    }
+                },
+                "description": {
+                    "type": "object",
+                    "title": "Description",
+                    "description": "The colors used for autocompletion descriptions. These appear at the bottom of the Fig window.",
+                    "properties": {
+                        "textColor": {
+                            "title": "Description Text Color",
+                            "$ref": "#/definitions/color"
+                        },
+                        "backgroundColor": {
+                            "title": "Description Background Color",
+                            "$ref": "#/definitions/color"
+                        },
+                        "borderColor": {
+                            "title": "Description Border Color",
+                            "$ref": "#/definitions/color"
+                        }
+                    }
+                }
+            }
+        }
+        
+    },
+    "definitions": {
+        "color": {
+            "title": "Color",
+            "markdownDescription": "A CSS color value. Check out the [CSS Color Types](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) page for more information.",
+            "type": "string",
+            "examples": [
+                "#000000",
+                "rgb(0, 0, 0)"
+            ]
+        }
+    }
+}

--- a/template.json
+++ b/template.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./schema.json",
   "author": {
     "name": "<YOUR NAME>",
     "twitter": "@<YOUR TWITTER HANDLE>",

--- a/themes/synthwave-84.json
+++ b/themes/synthwave-84.json
@@ -1,0 +1,21 @@
+{
+  "author": {
+    "name": "Don Isaac",
+    "twitter": "",
+    "github": "DonIsaac"
+  },
+  "version": "1.0",
+  "theme": {
+    "textColor": "#e799ff",
+    "backgroundColor": "#2f003d",
+    "matchBackgroundColor": "#f4d7fa50",
+    "selection": {
+      "textColor": "#e799ff",
+      "backgroundColor": "#f4d7fa50"
+    },
+    "description": {
+      "textColor": "#fc28a8",
+      "borderColor": "#02A3AB"
+    }
+  }
+}

--- a/themes/synthwave-84.json
+++ b/themes/synthwave-84.json
@@ -1,7 +1,6 @@
 {
   "author": {
     "name": "Don Isaac",
-    "twitter": "",
     "github": "DonIsaac"
   },
   "version": "1.0",


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Created a [JSON Schema](https://json-schema.org/draft-07/json-schema-release-notes.html) file to describe theme configurations.

This PR also adds the `synthwave-84` theme, which is based on `the-unnamed` and the [Synthwave '84](https://marketplace.visualstudio.com/items?itemName=RobbOwen.synthwave-vscode) VSCode theme. 

The theme looks like this:
![image](https://user-images.githubusercontent.com/22823424/149826381-d44cc909-ebb0-4908-8ac0-04ad29247dd2.png)


**Additional info:**

There are probably parts of the schema that I got incorrect, as I wasn't sure exactly what fields are available and what values they can have. This needs checking before being merged.

Also, I would have liked to use glowing effects (via the [text-shadow](https://www.w3schools.com/css/css_text_shadow.asp) property) and linear gradients, but this is not currently possible. An issue is already open for this, withfig/fig#1548 