### PR TITLE
feat: add Solarized light and dark themes

### DIFF
--- a/themes/solarized-dark.json
+++ b/themes/solarized-dark.json
@@ -1,0 +1,21 @@
+{
+  "author": {
+    "name": "Ethan Schoonover",
+    "twitter": "@ethanschoonover",
+    "github": "altercation"
+  },
+  "version": "1.0",
+  "theme": {
+    "textColor": "#839496",
+    "backgroundColor": "#002b36",
+    "matchBackgroundColor": "#586e75",
+    "selection": {
+      "textColor": "#93a1a1",
+      "backgroundColor": "#268bd2"
+    },
+    "description": {
+      "textColor": "#839496",
+      "borderColor": "#073642"
+    }
+  }
+}

--- a/themes/solarized-light.json
+++ b/themes/solarized-light.json
@@ -1,0 +1,21 @@
+{
+  "author": {
+    "name": "Ethan Schoonover",
+    "twitter": "@ethanschoonover",
+    "github": "altercation"
+  },
+  "version": "1.0",
+  "theme": {
+    "textColor": "#657b83",
+    "backgroundColor": "#fdf6e3",
+    "matchBackgroundColor": "#93a1a1",
+    "selection": {
+      "textColor": "#586e75",
+      "backgroundColor": "#268bd2"
+    },
+    "description": {
+      "textColor": "#657b83",
+      "borderColor": "#eee8d5"
+    }
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This adds a feature; light and dark themes based on Ethan Schoonover's Solarized color palette.  See https://ethanschoonover.com/solarized/#usage-development for design principles.

**What is the current behavior? (You can also link to an open issue here)**

Currently we have ports of other popular themes, but no Solarized.

**What is the new behavior (if this is a feature change)?**

`solarized-dark` and `solarized-light` are selectable themes (note: I've tested these changes only by copying the themes into my `~/.fig/themes` directory, it's not clear to me how to integrate these themes into the app such that they appear in the settings GUI)

**Additional info:**
example of `solarized-dark`:
![Screen Shot 2022-01-20 at 1 14 28 PM](https://user-images.githubusercontent.com/154395/150398419-69a3505e-6a55-4e36-bb4d-513fa9451457.png)

example of `solarized-light` (my prompt looks strange b/c changing the theme is onerous, sorry):
![Screen Shot 2022-01-20 at 1 25 11 PM](https://user-images.githubusercontent.com/154395/150399055-47252407-e3e7-4799-9c9c-775e0a92c78e.png)

