### PR TITLE
feat: add port of `tokyo-night` theme

### DIFF
--- a/themes/tokyo-night.json
+++ b/themes/tokyo-night.json
@@ -1,0 +1,21 @@
+{
+  "author": {
+    "name": "Matt Kelly",
+    "twitter": "@mattkellyhacks",
+    "github": "mathisto"
+  },
+  "version": "1.0",
+  "theme": {
+    "backgroundColor": "#24283b",
+    "textColor": "#c0caf5",
+    "matchBackgroundColor": "#565f89",
+    "selection": {
+      "textColor": "#a9b1d6",
+      "backgroundColor": "#414868"
+    },
+    "description": {
+      "textColor": "#414868",
+      "borderColor": "#f7768e"
+    }
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
The PR adds a port of [Enkia's](https://github.com/enkia) venerable [Tokyo Night](https://github.com/enkia/tokyo-night-vscode-theme) theme. 

**What is the current behavior? (You can also link to an open issue here)**
Currently this theme is not included. LOL.

**What is the new behavior (if this is a feature change)?**
LOL. In the event this PR is accepted, upon merge the CI will start chugging and update the config repo with this new hawtness.

**Additional info:**
Thanks so much for this amazing tool.