### PR TITLE
feat: Add dubdub themes

### DIFF
--- a/themes/dubdub-dark.json
+++ b/themes/dubdub-dark.json
@@ -2,7 +2,7 @@
   "author": {
     "name": "Shawn McClelland",
     "twitter": "@gimballocked",
-    "github": "@shawnmcclelland"
+    "github": "shawnmcclelland"
   },
   "version": "1.0",
   "theme": {

--- a/themes/dubdub-dark.json
+++ b/themes/dubdub-dark.json
@@ -1,0 +1,21 @@
+{
+  "author": {
+    "name": "Shawn McClelland",
+    "twitter": "@gimballocked",
+    "github": "@shawnmcclelland"
+  },
+  "version": "1.0",
+  "theme": {
+    "textColor": "#ffffff",
+    "backgroundColor": "#292b34",
+    "matchBackgroundColor": "#4ca8a3",
+    "selection": {
+      "textColor": "#ffffff",
+      "backgroundColor": "#43454f"
+    },
+    "description": {
+      "textColor": "#f7d0a2",
+      "borderColor": "#a9aab640"
+    }
+  }
+}

--- a/themes/dubdub-light.json
+++ b/themes/dubdub-light.json
@@ -1,0 +1,21 @@
+{
+  "author": {
+    "name": "Shawn McClelland",
+    "twitter": "@gimballocked",
+    "github": "shawnmcclelland"
+  },
+  "version": "1.0",
+  "theme": {
+    "textColor": "#2a2c36",
+    "backgroundColor": "#fffeff",
+    "matchBackgroundColor": "#ddfeb6",
+    "selection": {
+      "textColor": "#2a2c36",
+      "backgroundColor": "#a9abb5"
+    },
+    "description": {
+      "textColor": "#6161b9",
+      "borderColor": "#a9aab640"
+    }
+  }
+}


### PR DESCRIPTION
Adds dubdub-dark and dubdub-light profiles for fig autocomplete

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
- Feature: addition to themes

**What is the current behavior? (You can also link to an open issue here)**
- No change to the theme behaviour other than adding two new entries to the available themes.

**What is the new behavior (if this is a feature change)?**
- Theme can be set via `fig settings autocomplete.theme dubdub-light` and `fig settings autocomplete.theme dubdub-dark`

**Additional info:**
Dubdub Light Theme
<img width="326" alt="dubdub-light" src="https://user-images.githubusercontent.com/7469168/161429966-32fa1c59-71a0-40c6-920e-ce09c95d8bc9.png">

Dubdub Dark Theme
<img width="326" alt="dubdub-dark" src="https://user-images.githubusercontent.com/7469168/161429980-0d0a8d2f-1c85-4c23-bbad-88972099d67e.png">