### PR TITLE
feat: add sequoia theme

### DIFF
--- a/themes/sequoia.json
+++ b/themes/sequoia.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "../schema.json",
+  "author": {
+    "name": "Abhishek Aryan",
+    "twitter": "lunchb0ne",
+    "github": "lunchb0ne"
+  },
+  "version": "1.0",
+  "theme": {
+    "textColor": "#fdfdfe",
+    "backgroundColor": "#0F1014",
+    "matchBackgroundColor": "#c58fff",
+    "selection": {
+      "textColor": "#8eb6f5",
+      "backgroundColor": "#43444D",
+      "matchBackgroundColor": "#373643"
+    },
+    "description": {
+      "textColor": "#868690",
+      "borderColor": "#575861",
+      "backgroundColor": "#0F1014"
+    }
+  }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Feature: Added `sequoia` as a usable theme.  
Original from: https://sequoiatheme.com/

**What is the current behavior? (You can also link to an open issue here)**
You cannot select `sequoia` as a theme in fig :(

**What is the new behavior (if this is a feature change)?**
You can select `sequoia` as a theme in fig :)

**Additional info:**
Here are some preview images:
<img width="571" alt="CleanShot 2023-05-03 at 11 43 17@2x" src="https://user-images.githubusercontent.com/22198661/236066755-58ac3a0b-fbac-49ea-9628-ea1784099f35.png">
<img width="568" alt="CleanShot 2023-05-03 at 11 43 47@2x" src="https://user-images.githubusercontent.com/22198661/236066765-4a593625-e887-4db7-8c24-3ce5c546cf90.png">

