### PR TITLE
fix: update `template.json` to point to the correct schema

### DIFF
--- a/template.json
+++ b/template.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./schema.json",
+  "$schema": "../schema.json",
   "author": {
     "name": "<YOUR NAME>",
     "twitter": "@<YOUR TWITTER HANDLE>",


### PR DESCRIPTION
Update the `template.json` to point to the correct schema after the copy is done, to `themes/`.

Just a QOL change as the README instructs to copy the template to the `themes/` folder.