### PR TITLE
feat: add vesper-dark theme

### DIFF
--- a/themes/vesper-dark.json
+++ b/themes/vesper-dark.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../schema.json",
+  "author": {
+    "name": "Igor Bedesqui",
+    "twitter": "@bedesqui",
+    "github": "bdsqqq"
+  },
+  "version": "1.0",
+  "theme": {
+    "textColor": "#FFFFFF",
+    "backgroundColor": "#101010",
+    "matchBackgroundColor": "#FFC799",
+    "selection": {
+      "textColor": "#FFFFFF",
+      "backgroundColor": "#FFFFFF25"
+    },
+    "description": {
+      "textColor": "#FFFFFF",
+      "borderColor": "#101010"
+    }
+  }
+}


### PR DESCRIPTION
Based on the [Vesper theme](https://github.com/raunofreiberg/vesper) for VSCODE from [raunofreiberg](https://github.com/raunofreiberg/vesper/commits?author=raunofreiberg)

<img width="497" alt="image" src="https://github.com/withfig/themes/assets/37847523/d6ae00a1-dc5c-42f6-ba3b-7395f1428b5d">
