### PR TITLE
Added homebrew.json theme

### DIFF
--- a/themes/homebrew.json
+++ b/themes/homebrew.json
@@ -1,0 +1,20 @@
+{
+  "author": {
+    "github": "devantler",
+    "name": "Nikolai Emil Damm"
+  },
+  "theme": {
+    "backgroundColor": "#000000",
+    "description": {
+      "borderColor": "#052f30",
+      "textColor": "#37bc27"
+    },
+    "matchBackgroundColor": "#98c379",
+    "selection": {
+      "backgroundColor": "#031d1f",
+      "textColor": "#00ff00"
+    },
+    "textColor": "#00ff00"
+  },
+  "version": "1.0"
+}


### PR DESCRIPTION
This theme adds the Homebrew theme available in Terminal after installing Homebrew. The colors used is inspired by the Homebrew themes on:

- <https://github.com/lysyi3m/macos-terminal-themes>
- <https://iterm2colorschemes.com> 

It looks like this:

![image](https://github.com/withfig/themes/assets/26203420/86fae06d-6812-45c0-bbbd-3127a6e3e88d)
