### PR TITLE
Update cobalt2.json selection text color

### DIFF
--- a/themes/cobalt2.json
+++ b/themes/cobalt2.json
@@ -10,7 +10,7 @@
     "backgroundColor": "#1b2c3f",
     "matchBackgroundColor": "#6b8039",
     "selection": {
-      "textColor": "#fff",
+      "textColor": "#ffffff",
       "backgroundColor": "#193549"
     },
     "description": {


### PR DESCRIPTION
It appears that `fig/cw` doesn't like the abbreviated color value. Update to be explicit: `#fff` => `#ffffff`